### PR TITLE
Parse sentiment and show if we're unsure

### DIFF
--- a/sentiment-analysis-rust/assets/dynamic.js
+++ b/sentiment-analysis-rust/assets/dynamic.js
@@ -64,8 +64,10 @@ function updateCard(cardIndex, sentence, sentiment) {
     badge = `<span class="badge badge-success">Positive</span>`;
   } else if (sentiment === "negative") {
     badge = `<span class="badge badge-error">Negative</span>`;
-  } else {
+  } else if (sentiment === "neutral") {
     badge = `<span class="badge badge-ghost">Neutral</span>`;
+  } else {
+    badge = `<span class="badge badge-ghost">Unsure</span>`;
   }
   var cardElement = document.getElementById("card-" + cardIndex);
   cardElement.innerHTML = `

--- a/sentiment-analysis-rust/src/lib.rs
+++ b/sentiment-analysis-rust/src/lib.rs
@@ -1,9 +1,11 @@
+use std::str::FromStr;
+
 use anyhow::Result;
 use spin_sdk::{
     http::{Params, Request, Response, Router},
     http_component,
     key_value::Store,
-    llm::{infer, InferencingModel::Llama2Chat},
+    llm::{infer_with_options, InferencingModel::Llama2Chat},
 };
 
 use serde::{Deserialize, Serialize};
@@ -19,18 +21,23 @@ pub struct SentimentAnalysisResponse {
 }
 
 const PROMPT: &str = r#"\
+<<SYS>>
 You are a bot that generates sentiment analysis responses. Respond with a single positive, negative, or neutral.
+<</SYS>>
+<INST>
+Follow the pattern of the following examples:
 
-Hi, my name is Bob
-neutral
+User: Hi, my name is Bob
+Bot: neutral
 
-I am so happy today
-positive
+User: I am so happy today
+Bot: positive
 
-I am so sad today
-negative
+User: I am so sad today
+Bot: negative
+</INST>
 
-<SENTENCE>
+User: {SENTENCE}
 "#;
 
 /// A Spin HTTP component that internally routes requests.
@@ -50,15 +57,17 @@ fn not_found(_: Request, _: Params) -> Result<Response> {
 
 fn perform_sentiment_analysis(req: Request, _: Params) -> Result<Response> {
     let request = body_json_to_map(&req)?;
-    println!("Performing sentiment analysis on: {}", &request.sentence);
+    // Do some basic clean up on the input
+    let sentence = request.sentence.trim();
+    println!("Performing sentiment analysis on: {}", sentence);
 
     // Prepare the KV store
     let kv = Store::open_default()?;
 
     // If the sentiment of the sentence is already in the KV store, return it
-    if kv.exists(&request.sentence).unwrap_or(false) {
+    if kv.exists(sentence).unwrap_or(false) {
         println!("Found sentence in KV store returning cached sentiment");
-        let sentiment = kv.get(&request.sentence)?;
+        let sentiment = kv.get(sentence)?;
         let resp = SentimentAnalysisResponse {
             sentiment: std::str::from_utf8(&sentiment)?.to_string(),
         };
@@ -72,23 +81,35 @@ fn perform_sentiment_analysis(req: Request, _: Params) -> Result<Response> {
 
     // Otherwise, perform sentiment analysis
     println!("Running inference");
-    let inferencing_result = infer(
+    let inferencing_result = infer_with_options(
         Llama2Chat,
-        &PROMPT.clone().replace("<SENTENCE>", &request.sentence),
+        &PROMPT.replace("{SENTENCE}", sentence),
+        spin_sdk::llm::InferencingParams {
+            max_tokens: 6,
+            ..Default::default()
+        },
     )?;
     println!("Inference result {:?}", inferencing_result);
     let sentiment = inferencing_result
         .text
-        .split("\n")
+        .lines()
         .next()
-        .unwrap_or_default();
+        .unwrap_or_default()
+        .strip_prefix("Bot:")
+        .unwrap_or_default()
+        .parse::<Sentiment>();
+    println!("Got sentiment: {sentiment:?}");
 
+    if let Ok(sentiment) = sentiment {
+        println!("Caching sentiment in KV store");
+        kv.set(sentence, sentiment)?;
+    }
     // Cache the result in the KV store
-    println!("Caching sentiment in KV store");
-    kv.set(&request.sentence, sentiment.clone())?;
-
     let resp = SentimentAnalysisResponse {
-        sentiment: sentiment.to_string(),
+        sentiment: sentiment
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default(),
     };
 
     let resp_str = serde_json::to_string(&resp)?;
@@ -104,4 +125,47 @@ fn body_json_to_map(req: &Request) -> Result<SentimentAnalysisRequest> {
     };
 
     Ok(serde_json::from_slice::<SentimentAnalysisRequest>(&body)?)
+}
+
+#[derive(Copy, Clone, Debug)]
+enum Sentiment {
+    Positive,
+    Negative,
+    Neutral,
+}
+
+impl Sentiment {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Positive => "positive",
+            Self::Negative => "negative",
+            Self::Neutral => "neutral",
+        }
+    }
+}
+
+impl std::fmt::Display for Sentiment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl AsRef<[u8]> for Sentiment {
+    fn as_ref(&self) -> &[u8] {
+        self.as_str().as_bytes()
+    }
+}
+
+impl FromStr for Sentiment {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let sentiment = match s.trim() {
+            "positive" => Self::Positive,
+            "negative" => Self::Negative,
+            "neutral" => Self::Neutral,
+            _ => return Err(s.into()),
+        };
+        Ok(sentiment)
+    }
 }


### PR DESCRIPTION
This PR changes how we do sentiment analysis:
* Changes the prompt to something the worked better for me in my experiments (using the llama <<SYS>> and <INST> tags. 
* Parse the sentiment analysis so we can have more fine grained control on the logic
* Have the front-end show "unsure" if the backend did not return one of the three possible results
* Only ask for 6 tokens back to avoid getting longer responses than we'll ever use
* Only save to the cache if the parsing of the sentiment was successful
* Trim the input