### PR TITLE
Use llama prompt hints in ts sentiment example

### DIFF
--- a/sentiment-analysis-ts/assets/dynamic.js
+++ b/sentiment-analysis-ts/assets/dynamic.js
@@ -41,7 +41,7 @@ function newCard() {
 
   console.log("Running inference on sentence: " + sentence);
   runningInference = true;
-  fetch("http://localhost:3000/api/sentiment-analysis", {
+  fetch("/api/sentiment-analysis", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -64,8 +64,10 @@ function updateCard(cardIndex, sentence, sentiment) {
     badge = `<span class="badge badge-success">Positive</span>`;
   } else if (sentiment === "negative") {
     badge = `<span class="badge badge-error">Negative</span>`;
-  } else {
+  } else if (sentiment === "neutral") {
     badge = `<span class="badge badge-ghost">Neutral</span>`;
+  } else {
+    badge = `<span class="badge badge-ghost">Unsure</span>`;
   }
   var cardElement = document.getElementById("card-" + cardIndex);
   cardElement.innerHTML = `

--- a/sentiment-analysis-ts/src/index.ts
+++ b/sentiment-analysis-ts/src/index.ts
@@ -20,7 +20,11 @@ interface SentimentAnalysisResponse {
 const decoder = new TextDecoder();
 
 const PROMPT = `\
+<<SYS>>
 You are a bot that generates sentiment analysis responses. Respond with a single positive, negative, or neutral.
+<</SYS>>
+[INST]
+Follow the pattern of the following examples:
 
 Hi, my name is Bob
 neutral
@@ -30,6 +34,7 @@ positive
 
 I am so sad today
 negative
+[/INST]
 
 <SENTENCE>
 `;

--- a/sentiment-analysis-ts/src/index.ts
+++ b/sentiment-analysis-ts/src/index.ts
@@ -84,7 +84,7 @@ async function performSentimentAnalysis(request: HttpRequest) {
   }
 
   // Cache the result in the KV store
-  if (sentiment === "unsure") {
+  if (sentiment !== "unsure") {
     console.log("Caching sentiment in KV store");
     kv.set(sentence, sentiment);
   }


### PR DESCRIPTION
This changes the TS sentiment example to use the same llama2 prompt hints that the Rust example uses. This should hopefully improve results. 