### PR TITLE
chore(*-rs): update spin crate versions to v1.5.0

### DIFF
--- a/code-generator-rs/Cargo.lock
+++ b/code-generator-rs/Cargo.lock
@@ -917,7 +917,7 @@ dependencies = [
 [[package]]
 name = "spin-macro"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?branch=llm-sdk#b918220f940691212d7e2758f2f4f765ecf1693a"
+source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -929,8 +929,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "1.5.0-pre0"
-source = "git+https://github.com/fermyon/spin?branch=llm-sdk#b918220f940691212d7e2758f2f4f765ecf1693a"
+version = "1.5.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
 dependencies = [
  "anyhow",
  "bytes",

--- a/code-generator-rs/api/Cargo.toml
+++ b/code-generator-rs/api/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["cdylib"]
 anyhow = "1"
 bytes = "1"
 http = "0.2"
-spin-sdk = { git = "https://github.com/fermyon/spin", branch = "llm-sdk" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v1.5.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/openapi-rs/api/Cargo.lock
+++ b/openapi-rs/api/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 [[package]]
 name = "spin-macro"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?branch=llm-sdk#58a8f70efe612d2e1b380b0170d71b9df17de70b"
+source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -259,8 +259,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "1.5.0-pre0"
-source = "git+https://github.com/fermyon/spin?branch=llm-sdk#58a8f70efe612d2e1b380b0170d71b9df17de70b"
+version = "1.5.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
 dependencies = [
  "anyhow",
  "bytes",

--- a/openapi-rs/api/Cargo.toml
+++ b/openapi-rs/api/Cargo.toml
@@ -14,6 +14,6 @@ bytes = "1"
 http = "0.2"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
-spin-sdk = { git = "https://github.com/fermyon/spin", branch = "llm-sdk" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v1.5.0" }
 
 [workspace]

--- a/sentiment-analysis-rs/Cargo.lock
+++ b/sentiment-analysis-rs/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 [[package]]
 name = "spin-macro"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?branch=llm-sdk#ca520925df9dd57524041a0cecbed704341253a9"
+source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -259,8 +259,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "1.5.0-pre0"
-source = "git+https://github.com/fermyon/spin?branch=llm-sdk#ca520925df9dd57524041a0cecbed704341253a9"
+version = "1.5.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
 dependencies = [
  "anyhow",
  "bytes",

--- a/sentiment-analysis-rs/Cargo.toml
+++ b/sentiment-analysis-rs/Cargo.toml
@@ -19,6 +19,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"
 
 # The Spin SDK.
-spin-sdk = { git = "https://github.com/fermyon/spin", branch = "llm-sdk" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v1.5.0" }
 
 [workspace]


### PR DESCRIPTION
Bump the spin crate version to the latest v1.5.0 release for the Rust apps